### PR TITLE
[FEAT] 검색 뷰 구현 

### DIFF
--- a/Daylist/Daylist.xcodeproj/project.pbxproj
+++ b/Daylist/Daylist.xcodeproj/project.pbxproj
@@ -87,6 +87,13 @@
 		33B131942860926400916CCB /* CalendarSummaryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33B131932860926400916CCB /* CalendarSummaryModel.swift */; };
 		33B131962860B66500916CCB /* CalendarSummaryType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33B131952860B66500916CCB /* CalendarSummaryType.swift */; };
 		33B1319A2860BCBB00916CCB /* Adjusted+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33B131992860BCBB00916CCB /* Adjusted+.swift */; };
+		33B131A62860D43800916CCB /* SearchVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33B131A52860D43800916CCB /* SearchVC.swift */; };
+		33B131A82860D45B00916CCB /* SearchVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33B131A72860D45B00916CCB /* SearchVM.swift */; };
+		33B131AC2860D48600916CCB /* SearchTVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33B131AB2860D48600916CCB /* SearchTVC.swift */; };
+		33B131AE2860D4B200916CCB /* SearchDataResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33B131AD2860D4B200916CCB /* SearchDataResponse.swift */; };
+		33B131B12860D6E500916CCB /* DataSourceSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33B131B02860D6E500916CCB /* DataSourceSearch.swift */; };
+		33B131B32860D78D00916CCB /* SearchDataRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33B131B22860D78D00916CCB /* SearchDataRequest.swift */; };
+		33B131B52860DBC500916CCB /* UITableView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33B131B42860DBC500916CCB /* UITableView+.swift */; };
 		9D6DA303C98BFFC9E7AA0B21 /* Pods_Daylist.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 857655EDBDE2423C5BC9010E /* Pods_Daylist.framework */; };
 /* End PBXBuildFile section */
 
@@ -173,6 +180,13 @@
 		33B131932860926400916CCB /* CalendarSummaryModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CalendarSummaryModel.swift; sourceTree = "<group>"; };
 		33B131952860B66500916CCB /* CalendarSummaryType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarSummaryType.swift; sourceTree = "<group>"; };
 		33B131992860BCBB00916CCB /* Adjusted+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Adjusted+.swift"; sourceTree = "<group>"; };
+		33B131A52860D43800916CCB /* SearchVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchVC.swift; sourceTree = "<group>"; };
+		33B131A72860D45B00916CCB /* SearchVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchVM.swift; sourceTree = "<group>"; };
+		33B131AB2860D48600916CCB /* SearchTVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTVC.swift; sourceTree = "<group>"; };
+		33B131AD2860D4B200916CCB /* SearchDataResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchDataResponse.swift; sourceTree = "<group>"; };
+		33B131B02860D6E500916CCB /* DataSourceSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataSourceSearch.swift; sourceTree = "<group>"; };
+		33B131B22860D78D00916CCB /* SearchDataRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchDataRequest.swift; sourceTree = "<group>"; };
+		33B131B42860DBC500916CCB /* UITableView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+.swift"; sourceTree = "<group>"; };
 		857655EDBDE2423C5BC9010E /* Pods_Daylist.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Daylist.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AE0C2DD3BA6B9360AC3069AE /* Pods-Daylist.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Daylist.release.xcconfig"; path = "Target Support Files/Pods-Daylist/Pods-Daylist.release.xcconfig"; sourceTree = "<group>"; };
 		C89BF158F45A4705FA3DC9D1 /* Pods-Daylist.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Daylist.debug.xcconfig"; path = "Target Support Files/Pods-Daylist/Pods-Daylist.debug.xcconfig"; sourceTree = "<group>"; };
@@ -274,6 +288,7 @@
 				33B131992860BCBB00916CCB /* Adjusted+.swift */,
 				235E88712860DC540028F4A3 /* UIApplication+.swift */,
 				235E88732860DC660028F4A3 /* UIWindow+.swift */,
+				33B131B42860DBC500916CCB /* UITableView+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -392,6 +407,7 @@
 		23AAFBF42854844B00D7801A /* Screen */ = {
 			isa = PBXGroup;
 			children = (
+				33B131A02860D41400916CCB /* Search */,
 				237A68652855D7E100E6A890 /* Share */,
 				23AAFBF72854846600D7801A /* Home */,
 				23AAFBF62854846000D7801A /* Add */,
@@ -568,6 +584,75 @@
 			path = Response;
 			sourceTree = "<group>";
 		};
+		33B131A02860D41400916CCB /* Search */ = {
+			isa = PBXGroup;
+			children = (
+				33B131A42860D42600916CCB /* ViewController */,
+				33B131A32860D42200916CCB /* ViewModel */,
+				33B131A22860D41C00916CCB /* Model */,
+				33B131A12860D41900916CCB /* Cell */,
+			);
+			path = Search;
+			sourceTree = "<group>";
+		};
+		33B131A12860D41900916CCB /* Cell */ = {
+			isa = PBXGroup;
+			children = (
+				33B131AB2860D48600916CCB /* SearchTVC.swift */,
+			);
+			path = Cell;
+			sourceTree = "<group>";
+		};
+		33B131A22860D41C00916CCB /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				33B131AF2860D6D500916CCB /* DataSource */,
+				33B131A92860D46300916CCB /* Request */,
+				33B131AA2860D46700916CCB /* Response */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		33B131A32860D42200916CCB /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				33B131A72860D45B00916CCB /* SearchVM.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		33B131A42860D42600916CCB /* ViewController */ = {
+			isa = PBXGroup;
+			children = (
+				33B131A52860D43800916CCB /* SearchVC.swift */,
+			);
+			path = ViewController;
+			sourceTree = "<group>";
+		};
+		33B131A92860D46300916CCB /* Request */ = {
+			isa = PBXGroup;
+			children = (
+				33B131B22860D78D00916CCB /* SearchDataRequest.swift */,
+			);
+			path = Request;
+			sourceTree = "<group>";
+		};
+		33B131AA2860D46700916CCB /* Response */ = {
+			isa = PBXGroup;
+			children = (
+				33B131AD2860D4B200916CCB /* SearchDataResponse.swift */,
+			);
+			path = Response;
+			sourceTree = "<group>";
+		};
+		33B131AF2860D6D500916CCB /* DataSource */ = {
+			isa = PBXGroup;
+			children = (
+				33B131B02860D6E500916CCB /* DataSourceSearch.swift */,
+			);
+			path = DataSource;
+			sourceTree = "<group>";
+		};
 		F7E56C7E2C6BF69D20912D2D /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -713,6 +798,7 @@
 				23A933CD28577209009E4CEE /* LoadingView.swift in Sources */,
 				2373321E2856FA2E00D9814A /* YoutubeSearchVC.swift in Sources */,
 				230364B2285F3368003739F2 /* LockType.swift in Sources */,
+				33B131B32860D78D00916CCB /* SearchDataRequest.swift in Sources */,
 				237A6846285494D200E6A890 /* Service.swift in Sources */,
 				237A683B2854938F00E6A890 /* AddVC.swift in Sources */,
 				33B1318B285FB37700916CCB /* CalendarRequestModel.swift in Sources */,
@@ -753,10 +839,12 @@
 				237A68392854938400E6A890 /* AddModel.swift in Sources */,
 				333A6757285DE76200618BD5 /* CalendarSummaryView.swift in Sources */,
 				237A68712855DB9400E6A890 /* NavigationBar.swift in Sources */,
+				33B131A62860D43800916CCB /* SearchVC.swift in Sources */,
 				237332212856FB0C00D9814A /* YoutubeSearchTVC.swift in Sources */,
 				237A686228549AFC00E6A890 /* UIFont+.swift in Sources */,
 				33B1318F2860846A00916CCB /* String.swift in Sources */,
 				237A68522854987500E6A890 /* NotificationCenter+.swift in Sources */,
+				33B131B52860DBC500916CCB /* UITableView+.swift in Sources */,
 				237A682D28548E3000E6A890 /* BaseViewController.swift in Sources */,
 				23036499285DDFF6003739F2 /* EmbedSelectVC.swift in Sources */,
 				237A68582854992100E6A890 /* UITextView+.swift in Sources */,
@@ -767,6 +855,8 @@
 				237A68542854989500E6A890 /* UIView+.swift in Sources */,
 				237A683D285493B300E6A890 /* AddVM.swift in Sources */,
 				230D733828606C9400582792 /* ToastView.swift in Sources */,
+				33B131A82860D45B00916CCB /* SearchVM.swift in Sources */,
+				33B131B12860D6E500916CCB /* DataSourceSearch.swift in Sources */,
 				230D733A28606CBA00582792 /* ToastType.swift in Sources */,
 				2303649B285E06C7003739F2 /* EmbedVC.swift in Sources */,
 				2373321C28565BF200D9814A /* UIColor+.swift in Sources */,
@@ -775,7 +865,9 @@
 				235E88742860DC660028F4A3 /* UIWindow+.swift in Sources */,
 				333A6754285DD78D00618BD5 /* BaseNavigationController.swift in Sources */,
 				333A675E285E370F00618BD5 /* WeekCVC.swift in Sources */,
+				33B131AC2860D48600916CCB /* SearchTVC.swift in Sources */,
 				237A6849285494F100E6A890 /* APIError.swift in Sources */,
+				33B131AE2860D4B200916CCB /* SearchDataResponse.swift in Sources */,
 				230364AA285F12F9003739F2 /* UIDevice+.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Daylist/Daylist/Global/Class/BaseViewController.swift
+++ b/Daylist/Daylist/Global/Class/BaseViewController.swift
@@ -23,6 +23,7 @@ class BaseViewController: UIViewController {
         configureView()
         layoutView()
         bindRx()
+        hideKeyboard()
     }
     
     func configureView() {

--- a/Daylist/Daylist/Global/Extension/UITableView+.swift
+++ b/Daylist/Daylist/Global/Extension/UITableView+.swift
@@ -1,0 +1,17 @@
+//
+//  UITableView+.swift
+//  Daylist
+//
+//  Created by hwangJi on 2022/06/21.
+//
+
+import Foundation
+import UIKit
+
+extension UITableView {
+    
+    /// TableView 마지막 separator, 빈 셀 separator 숨기는 메서드
+    func removeSeparatorsOfEmptyCellsAndLastCell() {
+        tableFooterView = UIView(frame: CGRect(origin: .zero, size: CGSize(width: 0, height: 1)))
+    }
+}

--- a/Daylist/Daylist/Screen/Home/ViewController/HomeVC.swift
+++ b/Daylist/Daylist/Screen/Home/ViewController/HomeVC.swift
@@ -193,7 +193,8 @@ extension HomeVC {
         
         searchBtn.rx.tap
             .subscribe(onNext: {
-                // TODO: 검색뷰와 연결
+                let searchVC = SearchVC()
+                self.navigationController?.pushViewController(searchVC, animated: true)
             })
             .disposed(by: bag)
         

--- a/Daylist/Daylist/Screen/Search/Cell/SearchTVC.swift
+++ b/Daylist/Daylist/Screen/Search/Cell/SearchTVC.swift
@@ -1,0 +1,45 @@
+//
+//  SearchTVC.swift
+//  Daylist
+//
+//  Created by hwangJi on 2022/06/21.
+//
+
+import UIKit
+import Then
+import SnapKit
+
+final class SearchTVC: UITableViewCell {
+    
+    // MARK: Properties
+    var searchResultView = CalendarSummaryView().then {
+        $0.setBackgroundColor(isHome: false)
+    }
+
+    // MARK: - Init
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        configureUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        configureUI()
+    }
+    
+    override func layoutIfNeeded() {
+        searchResultView.cdPlayerView.playerCD.layer.cornerRadius = 44
+    }
+}
+
+// MARK: - UI
+
+extension SearchTVC {
+    private func configureUI() {
+        addSubview(searchResultView)
+        searchResultView.snp.makeConstraints {
+            $0.top.leading.trailing.bottom.equalToSuperview()
+        }
+    }
+}

--- a/Daylist/Daylist/Screen/Search/Model/DataSource/DataSourceSearch.swift
+++ b/Daylist/Daylist/Screen/Search/Model/DataSource/DataSourceSearch.swift
@@ -1,0 +1,23 @@
+//
+//  DataSourceSearch.swift
+//  Daylist
+//
+//  Created by hwangJi on 2022/06/21.
+//
+
+import Foundation
+import RxDataSources
+
+struct DataSourceSearch {
+    var section: Int
+    var items: [Item]
+}
+
+extension DataSourceSearch: SectionModelType {
+    typealias Item = SearchDataResponse
+    
+    init(original: DataSourceSearch, items: [SearchDataResponse]) {
+        self = original
+        self.items = items
+    }
+}

--- a/Daylist/Daylist/Screen/Search/Model/Request/SearchDataRequest.swift
+++ b/Daylist/Daylist/Screen/Search/Model/Request/SearchDataRequest.swift
@@ -1,0 +1,13 @@
+//
+//  SearchDataRequest.swift
+//  Daylist
+//
+//  Created by hwangJi on 2022/06/21.
+//
+
+import Foundation
+
+struct SearchDataRequest {
+    var userId: Int
+    var keyword: String
+}

--- a/Daylist/Daylist/Screen/Search/Model/Response/SearchDataResponse.swift
+++ b/Daylist/Daylist/Screen/Search/Model/Response/SearchDataResponse.swift
@@ -1,0 +1,23 @@
+//
+//  SearchDataResponse.swift
+//  Daylist
+//
+//  Created by hwangJi on 2022/06/21.
+//
+
+import Foundation
+
+// MARK: - SearchDataResponse
+struct SearchDataResponse: Codable {
+    let playlistID, userID: Int
+    let title, description, thumbnailImage, mediaLink: String
+    let emotion: Int
+    let createdAt: String
+
+    enum CodingKeys: String, CodingKey {
+        case playlistID = "playlistId"
+        case userID = "userId"
+        case title
+        case thumbnailImage, description, mediaLink, emotion, createdAt
+    }
+}

--- a/Daylist/Daylist/Screen/Search/ViewController/SearchVC.swift
+++ b/Daylist/Daylist/Screen/Search/ViewController/SearchVC.swift
@@ -22,6 +22,7 @@ final class SearchVC: BaseViewController {
         $0.tintColor = .black
         $0.isTranslucent = false
         $0.becomeFirstResponder()
+        $0.searchTextField.font = UIFont.KyoboHandwriting(size: 15.0)
         $0.backgroundImage = UIImage()
     }
     
@@ -153,6 +154,7 @@ extension SearchVC: UISearchBarDelegate {
     func searchBarTextDidBeginEditing(_ searchBar: UISearchBar) {
         let cancelBtn = searchBar.value(forKey: "cancelButton") as! UIButton
         cancelBtn.setTitle("나가기", for: .normal)
+        cancelBtn.titleLabel?.font = UIFont.KyoboHandwriting(size: 15.0)
     }
     
     /// searchBarCancelButtonClicked

--- a/Daylist/Daylist/Screen/Search/ViewController/SearchVC.swift
+++ b/Daylist/Daylist/Screen/Search/ViewController/SearchVC.swift
@@ -160,7 +160,19 @@ extension SearchVC: UISearchBarDelegate {
         self.navigationController?.popViewController(animated: true)
     }
     
+    /// searchBarSearchButtonClicked
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
         viewModel.postSearchData(with: SearchDataRequest(userId: 1, keyword: searchBar.searchTextField.text ?? ""))
+    }
+    
+    /// searchBarShouldEndEditing
+    func searchBarShouldEndEditing(_ searchBar: UISearchBar) -> Bool {
+        /// 키보드가 내려갈 때 endEditing 상태가 되어도 cancelBtn은 활성화되어있도록 설정
+        DispatchQueue.main.async {
+            if let cancelBtn = searchBar.value(forKey: "cancelButton") as? UIButton {
+                cancelBtn.isEnabled = true
+            }
+        }
+        return true
     }
 }

--- a/Daylist/Daylist/Screen/Search/ViewController/SearchVC.swift
+++ b/Daylist/Daylist/Screen/Search/ViewController/SearchVC.swift
@@ -1,0 +1,166 @@
+//
+//  SearchVC.swift
+//  Daylist
+//
+//  Created by hwangJi on 2022/06/21.
+//
+
+import UIKit
+import RxCocoa
+import RxGesture
+import RxSwift
+import RxDataSources
+import SnapKit
+import Then
+
+final class SearchVC: BaseViewController {
+    
+    // MARK: Properties
+    private var searchBar = UISearchBar().then {
+        $0.showsCancelButton = true
+        $0.searchBarStyle = .prominent
+        $0.tintColor = .black
+        $0.isTranslucent = false
+        $0.becomeFirstResponder()
+        $0.backgroundImage = UIImage()
+    }
+    
+    private var searchResultTV = UITableView().then {
+        $0.rowHeight = 144.adjustedH
+        $0.separatorInset = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 8)
+        $0.removeSeparatorsOfEmptyCellsAndLastCell()
+    }
+    
+    private var bag = DisposeBag()
+    private var viewModel = SearchVM()
+    
+    // MARK: Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+    
+    // MARK: Configure
+    
+    override func configureView() {
+        super.configureView()
+        configureSearchBar()
+        configureTableView()
+    }
+    
+    override func layoutView() {
+        super.layoutView()
+        configureUI()
+    }
+    
+    override func bindInput() {
+        super.bindInput()
+    }
+    
+    override func bindOutput() {
+        super.bindOutput()
+        bindLoading()
+        bindOnError()
+        bindDataSource()
+    }
+}
+
+// MARK: - Configure
+
+extension SearchVC {
+    private func configureTableView() {
+        searchResultTV.register(SearchTVC.self, forCellReuseIdentifier: SearchTVC.className)
+    }
+    
+    private func configureSearchBar() {
+        searchBar.delegate = self
+    }
+}
+
+// MARK: - Layout
+
+extension SearchVC {
+    private func configureUI() {
+        view.addSubviews([searchBar, searchResultTV])
+        
+        searchBar.snp.makeConstraints {
+            $0.top.equalTo(view.layoutMarginsGuide)
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(44)
+        }
+        
+        searchResultTV.snp.makeConstraints {
+            $0.top.equalTo(searchBar.snp.bottom)
+            $0.leading.trailing.bottom.equalToSuperview()
+        }
+    }
+}
+
+// MARK: - Output
+
+extension SearchVC {
+    private func bindLoading() {
+        viewModel.output.loading
+            .asDriver()
+            .drive(onNext: { [weak self] loading in
+                guard let self = self else { return }
+                self.loading(loading: loading)
+            })
+            .disposed(by: bag)
+    }
+    
+    private func bindOnError() {
+        viewModel.output.onError
+            .asDriver(onErrorJustReturn: .unknown)
+            .drive(onNext: { [weak self] error in
+                guard let self = self else { return }
+                self.showErrorAlert(error.description)
+            })
+            .disposed(by: bag)
+    }
+    
+    private func bindDataSource() {
+        let dataSource = dataSource()
+        
+        viewModel.output.dataSource
+            .bind(to: searchResultTV.rx.items(dataSource: dataSource))
+            .disposed(by: bag)
+    }
+}
+
+// MARK: - DataSource
+
+extension SearchVC {
+    private func dataSource() -> RxTableViewSectionedReloadDataSource<DataSourceSearch> {
+        let dataSource = RxTableViewSectionedReloadDataSource<DataSourceSearch> { _, tableView, indexPath, search in
+            guard let searchCell = tableView.dequeueReusableCell(withIdentifier: SearchTVC.className, for: indexPath) as? SearchTVC else { return UITableViewCell() }
+            searchCell.searchResultView.setData(isData: .exist, model: CalendarSummaryModel(thumbnailImageName: search.thumbnailImage,
+                                                                                            date: search.createdAt.serverTimeToString(dateFormat: "yyyy.MM.dd"),
+                                                                                            emotion: EmotionType(rawValue: search.emotion) ?? .happy,
+                                                                                            title: search.title,
+                                                                                            description: search.description))
+            return searchCell
+        }
+        
+        return dataSource
+    }
+}
+
+// MARK: - UISearchBarDelegate
+extension SearchVC: UISearchBarDelegate {
+    
+    /// searchBarTextDidBeginEditing
+    func searchBarTextDidBeginEditing(_ searchBar: UISearchBar) {
+        let cancelBtn = searchBar.value(forKey: "cancelButton") as! UIButton
+        cancelBtn.setTitle("나가기", for: .normal)
+    }
+    
+    /// searchBarCancelButtonClicked
+    func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
+        self.navigationController?.popViewController(animated: true)
+    }
+    
+    func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
+        viewModel.postSearchData(with: SearchDataRequest(userId: 1, keyword: searchBar.searchTextField.text ?? ""))
+    }
+}

--- a/Daylist/Daylist/Screen/Search/ViewController/SearchVC.swift
+++ b/Daylist/Daylist/Screen/Search/ViewController/SearchVC.swift
@@ -162,6 +162,7 @@ extension SearchVC: UISearchBarDelegate {
     
     /// searchBarSearchButtonClicked
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
+        view.endEditing(true)
         viewModel.postSearchData(with: SearchDataRequest(userId: 1, keyword: searchBar.searchTextField.text ?? ""))
     }
     

--- a/Daylist/Daylist/Screen/Search/ViewModel/SearchVM.swift
+++ b/Daylist/Daylist/Screen/Search/ViewModel/SearchVM.swift
@@ -1,0 +1,101 @@
+//
+//  SearchVM.swift
+//  Daylist
+//
+//  Created by hwangJi on 2022/06/21.
+//
+
+import Foundation
+import RxCocoa
+import RxSwift
+import Alamofire
+
+// MARK: - SearchViewModelOutput
+
+protocol SearchViewModelOutput: Lodable {
+    var searchData: BehaviorRelay<[SearchDataResponse]> { get }
+    
+    var onError: PublishSubject<APIError> { get }
+    
+    var dataSource: Observable<[DataSourceSearch]> { get }
+}
+
+extension SearchViewModelOutput {
+    var dataSource: Observable<[DataSourceSearch]> {
+        searchData
+            .map {
+                [DataSourceSearch(section: 0, items: $0)]
+            }
+    }
+}
+
+// MARK: - SearchVM
+
+final class SearchVM: BaseViewModel {
+    
+    var apiSession: APIService = APISession()
+    let apiError = PublishSubject<APIError>()
+    var bag = DisposeBag()
+    var input = Input()
+    var output = Output()
+    
+    // MARK: - Input
+    
+    struct Input {}
+    
+    // MARK: - Output
+    
+    struct Output: SearchViewModelOutput {
+        var searchData = BehaviorRelay<[SearchDataResponse]>(value: [])
+        var onError = PublishSubject<APIError>()
+        var loading = BehaviorRelay<Bool>(value: false)
+    }
+    
+    // MARK: - Init
+    
+    init() {
+        bindInput()
+        bindOutput()
+    }
+    
+    deinit {
+        bag = DisposeBag()
+    }
+}
+
+// MARK: - Input
+
+extension SearchVM {
+    func bindInput() {}
+}
+
+// MARK: - Output
+
+extension SearchVM {
+    func bindOutput() {}
+}
+
+// MARK: - Networking
+
+extension SearchVM {
+    func postSearchData(with param: SearchDataRequest) {
+        let path = "/search/\(param.userId)"
+        let resource = urlResource<[SearchDataResponse]>(path: path)
+        if output.isLoading { return }
+        output.beginLoading()
+        
+        apiSession.postRequest(with: resource, param: ["keyword": param.keyword])
+            .withUnretained(self)
+            .subscribe(onNext: { owner, result in
+                owner.output.endLoading()
+                switch result {
+                case .failure(let error):
+                    owner.apiError.onNext(error)
+                    
+                case .success(let data):
+                    owner.output.searchData.accept(data)
+                }
+            })
+            .disposed(by: bag)
+    }
+}

--- a/Daylist/Daylist/Screen/Share/CDPlayer/CDPlayerView.swift
+++ b/Daylist/Daylist/Screen/Share/CDPlayer/CDPlayerView.swift
@@ -15,7 +15,7 @@ class CDPlayerView: BaseView {
             $0.image = UIImage(named: "PlayerBase")
         }
     
-    private var playerCD = UIImageView()
+    private(set) var playerCD = UIImageView()
         .then {
             $0.clipsToBounds = true
         }

--- a/Daylist/Daylist/Screen/Share/CalendarSummaryView/CalendarSummaryView.swift
+++ b/Daylist/Daylist/Screen/Share/CalendarSummaryView/CalendarSummaryView.swift
@@ -14,7 +14,7 @@ class CalendarSummaryView: BaseView {
     
     // MARK: Properties
     
-    private var cdPlayerView = CDPlayerView()
+    private(set) var cdPlayerView = CDPlayerView()
     
     private var dateLabel = UILabel().then {
         $0.textColor = .mediumGray
@@ -78,7 +78,7 @@ extension CalendarSummaryView {
         cdPlayerView.snp.makeConstraints {
             $0.top.equalToSuperview().offset(10)
             $0.leading.equalToSuperview().offset(20)
-            $0.height.width.equalTo(calculateHeightbyScreenHeight(originalHeight: 113))
+            $0.height.width.equalTo(calculateHeightbyScreenHeight(originalHeight: 113.adjustedH))
         }
         
         dateLabel.snp.makeConstraints {
@@ -90,7 +90,7 @@ extension CalendarSummaryView {
         titleStackView.snp.makeConstraints {
             $0.top.equalTo(dateLabel.snp.bottom).offset(5)
             $0.leading.equalTo(dateLabel)
-            $0.trailing.equalTo(stylusImageView.snp.leading).inset(-27)
+            $0.trailing.equalTo(stylusImageView.snp.leading).inset(27)
             $0.height.equalTo(calculateHeightbyScreenHeight(originalHeight: 20))
         }
         
@@ -101,7 +101,7 @@ extension CalendarSummaryView {
         
         descriptionTextView.snp.makeConstraints {
             $0.top.equalTo(titleStackView.snp.bottom).offset(5)
-            $0.leading.trailing.equalTo(titleStackView)
+            $0.leading.equalTo(titleStackView.snp.leading)
             $0.trailing.equalTo(stylusImageView.snp.leading).offset(-20)
             $0.bottom.equalToSuperview().inset(20)
         }
@@ -155,7 +155,7 @@ extension CalendarSummaryView {
     private func setSummaryViewWhenDataExist() {
         descriptionTextView.snp.remakeConstraints {
             $0.top.equalTo(titleStackView.snp.bottom).offset(5)
-            $0.leading.trailing.equalTo(titleStackView)
+            $0.leading.equalTo(titleStackView)
             $0.trailing.equalTo(stylusImageView.snp.leading).offset(-20)
             $0.bottom.equalToSuperview().inset(20)
         }


### PR DESCRIPTION
## 🌈 PR 요약
- 검색 뷰 구현 & 홈화면 검색 아이콘과 연결

## 📌 변경 사항
- UITableView Extension 추가
- CDPlayerView private(set) 프로퍼티로 변경
- 화면 터치시 키보드 내리는 함수 hideKeyboard를 상속하는 VC들에서 일괄 사용할 수 있도록 BaseViewController의 viewDidLoad에 호출

## 📸 ScreenShot

https://user-images.githubusercontent.com/63224278/174661407-12d0d78b-2310-4ad8-b69f-1b4c490e536b.mp4



#### Linked Issue
closed #15
